### PR TITLE
fix: `play` should be `start` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Destroys the video
 Shows or hides the video player view
 
 
-## videoplayer.play(handle) / videoplayer.stop(handle) / videoplayer.pause(handle)
+## videoplayer.start(handle) / videoplayer.stop(handle) / videoplayer.pause(handle)
 
 
 # Example


### PR DESCRIPTION
This PR fixes a typo in the API section of the readme: `play` is not a function, so I believe it should be `start` instead.